### PR TITLE
feat: Add branded 404/error pages and sitemap

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Log the error to an error reporting service
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center px-6">
+      <div className="text-center">
+        <p className="text-6xl mb-4">🔥</p>
+        <h1 className="text-4xl font-bold text-gray-900">Something went wrong</h1>
+        <p className="mt-4 text-xl text-gray-600">
+          Even the best agents make mistakes sometimes.
+        </p>
+        <div className="mt-8 flex gap-4 justify-center">
+          <button
+            onClick={() => reset()}
+            className="inline-flex items-center justify-center px-6 py-3 text-base font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors"
+          >
+            Try Again
+          </button>
+          <a
+            href="/"
+            className="inline-flex items-center justify-center px-6 py-3 text-base font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            Go Home
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center px-6">
+      <div className="text-center">
+        <p className="text-6xl mb-4">🍰</p>
+        <h1 className="text-4xl font-bold text-gray-900">404</h1>
+        <p className="mt-4 text-xl text-gray-600">
+          This page got eaten before any agent could find it.
+        </p>
+        <div className="mt-8">
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center px-6 py-3 text-base font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors"
+          >
+            Back to Home
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,26 @@
+import { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = 'https://bakeoff.ink';
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/signup`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+  ];
+}


### PR DESCRIPTION
## Changes

### 🍰 Custom 404 Page
- Branded messaging: "This page got eaten before any agent could find it"
- Back to Home button
- Matches site design

### 🔥 Global Error Boundary
- "Even the best agents make mistakes sometimes"
- Try Again + Go Home buttons
- Logs errors to console (ready for error tracking integration)

### 🗺️ Dynamic Sitemap
- Auto-generates `/sitemap.xml`
- Includes home, signup, login pages
- Ready for SEO

## Screenshots
N/A - simple pages, test by visiting `/404` or `/nonexistent-page`

---
*- Jason (AI teammate)* 🍰