### PR TITLE
fix: Dashboard real data + task view for all

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,6 +1,45 @@
+import { getCurrentUser } from '@/lib/auth';
+import { connectDB } from '@/lib/db';
+import { Task, Submission } from '@/lib/db/models';
 import { PageHeader, Button, StatCard, Card, Tag } from '@/components/ui';
 
-export default function DashboardPage() {
+export default async function DashboardPage() {
+  const user = await getCurrentUser();
+  if (!user) return null;
+
+  await connectDB();
+
+  // Get real stats
+  const [activeTasks, pendingReviews, totalPaidOut] = await Promise.all([
+    // Active tasks (open)
+    Task.countDocuments({ posterId: user._id, status: 'open' }),
+    // Pending reviews (tasks with submissions but no winner yet)
+    Task.countDocuments({
+      posterId: user._id,
+      status: 'open',
+    }).then(async () => {
+      const tasksWithSubmissions = await Task.aggregate([
+        { $match: { posterId: user._id, status: 'open' } },
+        {
+          $lookup: {
+            from: 'submissions',
+            localField: '_id',
+            foreignField: 'taskId',
+            as: 'submissions',
+          },
+        },
+        { $match: { 'submissions.0': { $exists: true } } },
+        { $count: 'count' },
+      ]);
+      return tasksWithSubmissions[0]?.count || 0;
+    }),
+    // Total bounties paid (closed tasks)
+    Task.aggregate([
+      { $match: { posterId: user._id, status: 'closed' } },
+      { $group: { _id: null, total: { $sum: '$bounty' } } },
+    ]).then((result) => result[0]?.total || 0),
+  ]);
+
   return (
     <div className="space-y-10">
       <PageHeader
@@ -17,21 +56,21 @@ export default function DashboardPage() {
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
         <StatCard
           label="Active Tasks"
-          value="—"
+          value={activeTasks.toString()}
           badge={
             <Tag variant="green">Active</Tag>
           }
         />
         <StatCard
           label="Pending Reviews"
-          value="—"
+          value={pendingReviews.toString()}
           badge={
             <Tag variant="purple">Needs Action</Tag>
           }
         />
         <StatCard
           label="Total Bounties"
-          value="$0"
+          value={`$${(totalPaidOut / 100).toFixed(2)}`}
           subtext="paid out"
         />
       </div>

--- a/src/app/(dashboard)/tasks/[id]/page.tsx
+++ b/src/app/(dashboard)/tasks/[id]/page.tsx
@@ -20,9 +20,12 @@ export default async function TaskDetailPage({
   await connectDB();
   const task = await Task.findById(id).lean();
 
-  if (!task || task.posterId.toString() !== user._id.toString()) {
+  if (!task) {
     notFound();
   }
+
+  // Check if user is the task owner (for edit/cancel permissions)
+  const isOwner = task.posterId.toString() === user._id.toString();
 
   const submissions = await Submission.find({ taskId: task._id })
     .sort({ submittedAt: -1 })
@@ -52,9 +55,10 @@ export default async function TaskDetailPage({
   const agentMap = new Map(agents.map((a) => [a._id.toString(), a]));
 
   const canCancel =
+    isOwner &&
     (task.status === 'draft' || task.status === 'open') &&
     submissions.length === 0;
-  const canSelectWinner = task.status === 'open' && submissions.length > 0;
+  const canSelectWinner = isOwner && task.status === 'open' && submissions.length > 0;
 
   return (
     <div className="space-y-10">


### PR DESCRIPTION
Fixes:
1. Dashboard now shows real stats from DB
2. Task detail page viewable by anyone (not just owner)

Owner permissions still enforced for cancel/select-winner actions.